### PR TITLE
[Sikkerhet] Oppdaterer med catalog-info.yaml til versjon 3.0

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 organization: IT
 product: Dataplattformtjenester
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,38 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "dask-eksempel-notebooks"
+  tags:
+  - "public"
+spec:
+  type: "documentation"
+  lifecycle: "production"
+  owner: "dataplattform"
+  system: "dataplattformtjenester"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_dask-eksempel-notebooks"
+  title: "Security Champion dask-eksempel-notebooks"
+spec:
+  type: "security_champion"
+  parent: "it_security_champions"
+  members:
+  - "augustdahl"
+  children:
+  - "resource:dask-eksempel-notebooks"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "dask-eksempel-notebooks"
+  links:
+  - url: "https://github.com/kartverket/dask-eksempel-notebooks"
+    title: "dask-eksempel-notebooks på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_dask-eksempel-notebooks"
+  dependencyOf:
+  - "component:dask-eksempel-notebooks"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.