### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: IT
 product: Dataplattformtjenester
 repo_types: [Documentation]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,4 @@
 # Automatic assign the following users as reviewers when a pull request is opened
 * @kartverket/dask
 
-/.sikkerhet/ @augustdahl
+/.security/ @augustdahl

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "dataplattform"
   system: "dataplattformtjenester"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_dask-eksempel-notebooks"
-  title: "Security Champion dask-eksempel-notebooks"
-spec:
-  type: "security_champion"
-  parent: "it_security_champions"
-  members:
-  - "augustdahl"
-  children:
-  - "resource:dask-eksempel-notebooks"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "dask-eksempel-notebooks"
-  links:
-  - url: "https://github.com/kartverket/dask-eksempel-notebooks"
-    title: "dask-eksempel-notebooks på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_dask-eksempel-notebooks"
-  dependencyOf:
-  - "component:dask-eksempel-notebooks"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml